### PR TITLE
Configure signature version and region on upload

### DIFF
--- a/pg-s3-backup
+++ b/pg-s3-backup
@@ -46,8 +46,10 @@ dump() {
 }
 
 upload() {
+    # Configure aws signature version for server side encryption.
+    aws configure set s3.signature_version s3v4
     local s3path=${S3_URL%%/}/${localpath##*/}
-    aws s3 cp --quiet $localpath $s3path || abort "failed to upload dump"
+    aws s3 cp --only-show-errors $localpath $s3path || abort "failed to upload dump"
 }
 
 snitch () {


### PR DESCRIPTION
An aws signature version must be configured when doing server side
encryption.

Since us-west-1 has permanently been redirected to us-west-2 we need
to override the region on upload but the dump must still happen with
endpoint us-west-1.

I have archived the old docker as v1.01 and added this new version as v1.02 and latest.
![image](https://user-images.githubusercontent.com/30059933/45910572-0e3bbf80-bdbf-11e8-9960-ee5e29211a06.png)
